### PR TITLE
Dev/support mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Runner Config
 
-When you run your unit tests using both Karma and Wallaby, a lot of configuration such as the files list is duplicated.
-We like DRY, so put the files in a separate file list and load them into your Wallaby and Karma config using this script!
+When you run your unit tests using either Wallaby, Karma and Mocha, a lot of configuration such as the files list is duplicated.
+We like DRY, so put the files in a separate file list and load them into your Wallaby, Karma and/or Mocha config using this script!
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ npm i test-runner-config --save-dev
 ```
 
 Require testRunnerConfig in your karma.conf.js or wallaby.conf.js file and pass a structured file list to a `testRunnerConfig` method to get your configuration.
+Mocha is not supported because it passes the files as argument to the `mocha` command, but you can get a files list for the Grunt or Gulp task that runs Mocha.
 
 The file list should have the following format. You can use glob patterns, but note that Wallaby does not support them all.
 See [Wallaby issue 69](https://github.com/wallabyjs/public/issues/69)
@@ -33,10 +34,13 @@ See [Wallaby issue 69](https://github.com/wallabyjs/public/issues/69)
 
 ```javascript
 var testRunnerConfig = require('test-runner-config');
-var config = testRunnerConfig.getWallabyFiles(files); // For Karma config call getKarmaFiles()
+var config = testRunnerConfig.getWallabyFiles(files); // For Karma config call getKarmaFiles() and for Mocha call getMochaFiles()
 ```
 
-`config` contains the part of your Wallaby config with the files and specs, which you can merge into your Wallaby config object:
+`config` contains the part of your Wallaby config with the files and specs, which you can merge into your Wallaby config object.
+To get the files array for the Mocha grunt or Gulp task, call `testRunnerConfig.getMochaFiles(require('./test/testFiles.js'))`.
+
+This is now in the `config` variable.
 
 ```javascript
 {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "test-runner-config",
   "license": "MIT",
   "author": "Frank van Wijk <fvanwijk@xebia.com>",
-  "description": "Utility to create a shared files config for Wallaby and Karma",
-  "version": "0.2.1",
+  "description": "Utility to create a shared files config for Wallaby, Karma and Mocha",
+  "version": "0.3.0",
   "keywords": [
     "karma",
     "wallaby",

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,12 @@ function getKarmaFiles(files, mappings) {
   };
 }
 
+function getMochaFiles(files, mappings) {
+  return getKarmaFiles(files, mappings).files;
+}
+
 module.exports = {
   getWallabyFiles: getWallabyFiles,
-  getKarmaFiles: getKarmaFiles
+  getKarmaFiles: getKarmaFiles,
+  getMochaFiles: getMochaFiles
 };


### PR DESCRIPTION
Added Mocha support. Not for the command line, because anyone who wants to have a DRY test config does not run Mocha on the CLI, but uses Grunt/Gulp/etc.

Just call `testRunnerConfig.getMochaFiles(testFiles);` to get an array of the files that you can pass to Mocha.